### PR TITLE
Explicitly require /wp-admin/includes/plugin.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -3,6 +3,7 @@
 add_action( 'init', function() {
 	add_theme_support( 'align-wide' );
 	show_admin_bar( true );
+	require( ABSPATH.'/wp-admin/includes/plugin.php' );
 	require( ABSPATH.'/wp-admin/includes/class-wp-screen.php' );
 	require( ABSPATH.'/wp-admin/includes/screen.php' );
 	require( ABSPATH.'/wp-admin/includes/template.php' );


### PR DESCRIPTION
Explicitly require /wp-admin/includes/plugin.php to ensure
get_plugin_data() is defined.

See #3